### PR TITLE
Export correct API depending on environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1557,4 +1557,5 @@ posix.posix = win32.posix = posix;
 win32._makeLong = win32.toNamespacedPath;
 posix._makeLong = posix.toNamespacedPath;
 
-module.exports = posix;
+const isWindows = typeof process == 'object' && process.platform == 'win32';
+module.exports = isWindows ? win32 : posix;


### PR DESCRIPTION
We had some issues with using this module in a dynamic node + web environment, because Webpack kept injecting this module instead of using node's builtin `path`. While I'm not sure why webpack was doing that, modifying this module to export the correct API depending on the environment fixes the issue.

I figured it would be a useful addition, since it's backwards compatible in web environments. When running in a nodejs environment, it uses the `win32` API for Windows, and `posix` otherwise.
